### PR TITLE
fix #1, using id to fill svg color

### DIFF
--- a/lib/elements/SVG.js
+++ b/lib/elements/SVG.js
@@ -52,14 +52,14 @@ export const CircularHandle = ({ color, fuzziness, isPressed, trueRadius, visibl
     <PartialFillDef
       color={color}
       fuzziness={5}
-      id='partialRadialFill'
+      id={`partialRadialFill-${color}`}
       isPressed={isPressed}
       proportion={visibleRadius/trueRadius}
     />
     <ClickableCircle
       cx={cx}
       cy={cy}
-      fill="url(#partialRadialFill)"
+      fill={`url(#partialRadialFill-${color})`}
       onMouseDown={onMouseDown}
       onTouchStart={onTouchStart}
       r={trueRadius}


### PR DESCRIPTION
My fix is to put color into `id` name because it is the only thing we want to have more than one value in the `PartialFillDef`.